### PR TITLE
Update EBForeNotification.m

### DIFF
--- a/EBForeNotification/Classes/EBForeNotification.m
+++ b/EBForeNotification/Classes/EBForeNotification.m
@@ -70,7 +70,12 @@ NSString *const EBBannerViewDidClick = @"EBBannerViewDidClick";
     UIViewController *controller = [EBForeNotification appRootViewController];
     SharedBannerView.isIos10 = isIos10;
     SharedBannerView.userInfo = userInfo;
-    [controller.view addSubview:SharedBannerView];
+    // 避免AlertView 和 Banner 加载在同一个ViewController上。
+    if ([controller isKindOfClass:[UIAlertController class]]) {
+        [[UIApplication sharedApplication].keyWindow addSubview:SharedBannerView];
+    }else {
+        [controller.view addSubview:SharedBannerView];
+    }
 }
 
 +(UIViewController *)appRootViewController{


### PR DESCRIPTION
解决Bug：在AlerView展示的情况下，收到推送消息，结果AlertView被偏移到了屏幕的左上角。
解决方法：避免AlertView 和 Banner 加载在同一个ViewController上。
