### PR TITLE
Added support to loc-key notification content

### DIFF
--- a/EBForeNotification/Classes/EBBannerView.m
+++ b/EBForeNotification/Classes/EBBannerView.m
@@ -55,6 +55,24 @@ UIWindow *originWindow;
     }
 }
 
+-(NSString*) extractContentLabel:(NSDictionary*)userInfo{
+    NSObject *alertValue = userInfo[@"aps"][@"alert"];
+
+    if ([alertValue isKindOfClass:[NSString class]])
+        return alertValue;
+
+
+    if ([alertValue isKindOfClass:[NSDictionary class]]){
+        NSString *locKey = ((NSDictionary*)alertValue)[@"loc-key"];
+        if (locKey != nil)
+            return NSLocalizedString(locKey,nil);
+    }
+
+    @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                   reason:@"aps['alert'] field malformed: it is neither a string nor a dictionary with key 'loc-key'"
+                                 userInfo:nil];
+}
+
 -(void)setUserInfo:(NSDictionary *)userInfo{
     _userInfo = userInfo;
     UIImage *appIcon;
@@ -74,7 +92,7 @@ UIWindow *originWindow;
         assert(0);
     }
     self.title_label.text   = appName;
-    self.content_label.text = self.userInfo[@"aps"][@"alert"];
+    self.content_label.text = [self extractContentLabel:userInfo];
     self.time_label.text = EBBannerViewTimeText;
     [originWindow makeKeyAndVisible];
     if (!self.isIos10) {


### PR DESCRIPTION
According to [Apple Developer Guide](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) it is possible to use also a Dictionary as `aps alert` field value:

```
{
  "aps":{
    "alert": {
      "loc-key":"localizable_string_key"
    },
    "badge":1,
    "sound":"default"
  }
}
```

This commit added `loc-key` value support to localize alert title message.